### PR TITLE
消除对助手函数的依赖

### DIFF
--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -12,6 +12,7 @@
 namespace think\captcha;
 
 use think\Session;
+use think\Response;
 
 class Captcha
 {
@@ -206,7 +207,7 @@ class Captcha
         $content = ob_get_clean();
         imagedestroy($this->im);
 
-        return response($content, 200, ['Content-Length' => strlen($content)])->contentType('image/png');
+        return Response::create($content, '', 200, ['Content-Length' => strlen($content)])->contentType('image/png');
     }
 
     /**

--- a/src/helper.php
+++ b/src/helper.php
@@ -34,7 +34,9 @@ function captcha($id = "", $config = [])
  */
 function captcha_src($id = "")
 {
-    return \think\Url::build('/captcha' . ($id ? "/{$id}" : ''));
+    return \think\Url::build('\think\captcha\CaptchaController@index', [
+        'id' => $id,
+    ]);
 }
 
 /**


### PR DESCRIPTION
Captcha.php中使用了response()助手函数，而官方库不希望依赖任何助手函数。
helper.php中原来使用字符串连接方法构造url，改为控制器+数组传递参数方式构造url