### PR TITLE
修复手动验证方式验证的时候captcha相关配置项修改不生效的bug，同时规范了验证失败时的提示文本!

### DIFF
--- a/src/helper.php
+++ b/src/helper.php
@@ -11,40 +11,44 @@
 
 \think\Route::get('captcha/[:id]', "\\think\\captcha\\CaptchaController@index");
 
-\think\Validate::extend('captcha', function ($value, $id = "") {
-    return captcha_check($value, $id, (array) \think\Config::get('captcha'));
+\think\Validate::extend('captcha', function ($value, $id = '') {
+    return captcha_check($value, $id);
 });
 
-\think\Validate::setTypeMsg('captcha', '验证码错误!');
+\think\Validate::setTypeMsg('captcha', ':attribute错误!');
+
 
 /**
  * @param string $id
  * @param array  $config
  * @return \think\Response
  */
-function captcha($id = "", $config = [])
+function captcha($id = '', $config = [])
 {
     $captcha = new \think\captcha\Captcha($config);
     return $captcha->entry($id);
 }
 
+
 /**
  * @param $id
  * @return string
  */
-function captcha_src($id = "")
+function captcha_src($id = '')
 {
     return \think\Url::build('/captcha' . ($id ? "/{$id}" : ''));
 }
+
 
 /**
  * @param $id
  * @return mixed
  */
-function captcha_img($id = "")
+function captcha_img($id = '')
 {
     return '<img src="' . captcha_src($id) . '" alt="captcha" />';
 }
+
 
 /**
  * @param        $value
@@ -52,8 +56,8 @@ function captcha_img($id = "")
  * @param array  $config
  * @return bool
  */
-function captcha_check($value, $id = "", $config = [])
+function captcha_check($value, $id = '')
 {
-    $captcha = new \think\captcha\Captcha($config);
+    $captcha = new \think\captcha\Captcha((array)\think\Config::get('captcha'));
     return $captcha->check($value, $id);
 }


### PR DESCRIPTION
发现手动验证方式的时候，设置变量没办法替换，不知道是否有意为止，感觉体验不好，所以修复了一下。从原来的验证器验证方式读取captcha配置数组，传给captcha_check方法，改为直接在captcha_check中直接读取，避免两次传入代码冗余。还顺带修改了下提示文本，遵守验证码写法规范