### PR TITLE
修复自定义的session.prefix导致图形验证码验证时，验证码不正确问题

### DIFF
--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -11,6 +11,7 @@
 
 namespace think\captcha;
 
+use think\facade\Config;
 use think\facade\Session;
 
 class Captcha
@@ -198,7 +199,7 @@ class Captcha
         $secode                = [];
         $secode['verify_code'] = $code; // 把校验码保存到session
         $secode['verify_time'] = time(); // 验证码创建时间
-        Session::set($key . $id, $secode, '');
+        Session::set($key . $id, $secode, Config::pull('session.prefix'));
 
         ob_start();
         // 输出图像


### PR DESCRIPTION
从系统config里面获取session.prefix
如果没有设置这个，默认返回null