### PR TITLE
修改function captcha()的方法返回声明

### DIFF
--- a/src/helper.php
+++ b/src/helper.php
@@ -15,9 +15,9 @@ use think\Response;
 
 /**
  * @param string $config
- * @return \think\Response
+ * @return Response|array
  */
-function captcha($config = null): Response
+function captcha($config = null)
 {
     return Captcha::create($config);
 }


### PR DESCRIPTION
修改function captcha()的方法返回声明，因 src/Captcha.php 中create会返回Response|array两种类型，使用时报错。

解决config文件如下，api调用时报错。
return [
    // 是否采用API模式生成
    'api'      => true,
];